### PR TITLE
Agregar script descargador de YouTube a MP3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Descargador de música de YouTube (MP3)
+
+Este script descarga el audio de un video de YouTube y lo guarda como `.mp3` en la carpeta `MP3`.
+
+## Requisitos
+
+- Python 3.9+
+- `yt-dlp`
+- `ffmpeg` instalado y disponible en tu PATH
+
+## Instalación
+
+```bash
+pip install yt-dlp
+```
+
+## Uso
+
+```bash
+python download_youtube_mp3.py "https://www.youtube.com/watch?v=..."
+```
+
+Si quieres cambiar la carpeta destino:
+
+```bash
+python download_youtube_mp3.py "https://www.youtube.com/watch?v=..." --output-dir MP3
+```
+
+Los archivos descargados quedarán en la carpeta `MP3`.

--- a/download_youtube_mp3.py
+++ b/download_youtube_mp3.py
@@ -1,0 +1,44 @@
+import argparse
+from pathlib import Path
+
+import yt_dlp
+
+
+def download_mp3(url: str, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_template = str(output_dir / "%(title)s.%(ext)s")
+
+    ydl_opts = {
+        "format": "bestaudio/best",
+        "outtmpl": output_template,
+        "postprocessors": [
+            {
+                "key": "FFmpegExtractAudio",
+                "preferredcodec": "mp3",
+                "preferredquality": "192",
+            }
+        ],
+        "noplaylist": True,
+    }
+
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        ydl.download([url])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Descarga el audio de un video de YouTube en MP3."
+    )
+    parser.add_argument("url", help="URL del video de YouTube")
+    parser.add_argument(
+        "--output-dir",
+        default="MP3",
+        help="Carpeta destino para los MP3 (por defecto: MP3)",
+    )
+    args = parser.parse_args()
+
+    download_mp3(args.url, Path(args.output_dir))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Proveer una utilidad en Python que permita descargar el audio de un video de YouTube a `.mp3` a partir de una URL y almacenarlo en una carpeta `MP3`.
- Documentar requisitos y uso para que sea fácil de instalar y ejecutar con `yt-dlp` y `ffmpeg`.

### Description
- Añadido `download_youtube_mp3.py`, que expone un CLI y la función `download_mp3(url, output_dir)` que usa `yt_dlp` y el postprocesador `FFmpegExtractAudio` para generar MP3s en la carpeta `MP3` por defecto.
- Añadido `README.md` con requisitos (`yt-dlp`, `ffmpeg`), instrucciones de instalación (`pip install yt-dlp`) y ejemplos de uso con la opción `--output-dir`.
- Pequeña limpieza de importaciones en `download_youtube_mp3.py` (se eliminó el `import os` no usado).

### Testing
- No se ejecutaron pruebas automatizadas sobre el código en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69824f5d7cbc8329a22da75a8791b1de)